### PR TITLE
Added command to source bashrc using sshpass

### DIFF
--- a/rbe3002_lab4/src/launch_remote_turtlebot.sh
+++ b/rbe3002_lab4/src/launch_remote_turtlebot.sh
@@ -6,4 +6,4 @@ do
     esac
 done
 sleep 1
-sshpass -p "turtlebot" ssh ubuntu@$name.dyn.wpi.edu "roslaunch turtlebot3_bringup turtlebot3_robot_custom.launch multi_robot_name:='$name' set_lidar_frame_id:='$name/base_scan'"
+sshpass -p "turtlebot" ssh ubuntu@$name.dyn.wpi.edu "source ~/.bashrc" "roslaunch turtlebot3_bringup turtlebot3_robot_custom.launch multi_robot_name:='$name' set_lidar_frame_id:='$name/base_scan'"


### PR DESCRIPTION
Since the bashrc is not sourced, I was getting an error that "roslaunch command is not found". After making this change I got rid of the error.